### PR TITLE
[TASK] New hook to alter the user before writing it in the database

### DIFF
--- a/Classes/Service/CasAuthenticateService.php
+++ b/Classes/Service/CasAuthenticateService.php
@@ -34,12 +34,17 @@ class CasAuthenticateService extends \TYPO3\CMS\Sv\AbstractAuthenticationService
 	 */
 	public function authUser($user) {
 		$OK = false;
+
 		if ($this->mode == 'authUserFE') {
 			// user is the user data we read above, so if it's filled with data, it means
 			// the login worked great and that we have a valid user, so all we need to do now is
 			// authenticate him... 200 means the user is good to go
 			if ($user) {
 				$OK = 200;
+
+				$signalArguments = array($OK, $user, $this->configurationUtility->get('userGroupIdList'));
+				$signalArguments = $this->signalSlotDispatcher->dispatch(__CLASS__, 'onAfterUserAuthenticatedByCas', $signalArguments);
+				$OK = $signalArguments[0];
 			}
 		}
 

--- a/Classes/Service/CasAuthenticateService.php
+++ b/Classes/Service/CasAuthenticateService.php
@@ -46,6 +46,10 @@ class CasAuthenticateService extends \TYPO3\CMS\Sv\AbstractAuthenticationService
 				$signalArguments = $this->signalSlotDispatcher->dispatch(__CLASS__, 'onAfterUserAuthenticatedByCas', $signalArguments);
 				$OK = $signalArguments[0];
 			}
+
+			if ($OK < 0 && $this->configurationUtility->get('redirectToUrlOnFailedAuth')) {
+				\TYPO3\CMS\Core\Utility\HttpUtility::redirect($this->configurationUtility->get('redirectToUrlOnFailedAuth'));
+			}
 		}
 
 		return $OK;

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -31,5 +31,8 @@ userGroupIdList =
 # cat=basic; type=int; label=Feusers storage pid:You can define multiple domain configuration (multi-site) by prefixing value with domain. Ex: first-website.local:1|second-website.local:100
 userPid =
 
+# cat=basic; type=string; label=Redirect to this URL on failed auth:You can define multiple domain configuration (multi-site) by prefixing value with domain. Ex: first-website.local:http://example.com|second-website.local:http://other-example.com
+redirectToUrlOnFailedAuth =
+
 # cat=basic; type=int; label=Enable phpCAS debugging:0 : Disabled, -1: Enabled
 phpCasSetDebug = 0


### PR DESCRIPTION
Declare the hook like that (in your extension's ext_localconf.php):

```
$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['cas_authenticate']['onBeforeWriteFrontendUserInDatabase'][] = 'ACME\\Hook\\CasAuthenticateServiceHook';
```

The hook object must provide a method with this signature:

```
public function onBeforeWriteFrontendUserInDatabase(&$user, $casAttributes, $casAuthenticateService);
```